### PR TITLE
Add z-index to stop sidebar handle overlaying menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,7 @@ async function monkeyPatchContextMenus() {
       font-family: -apple-system, BlinkMacSystemFont, sans-serif;
       color: black;
       padding: 4px 0;
+      z-index: 12;
     }
     .context-menu ul:not(:first-child) {
       border-top: 2px solid rgb(145,148,153);


### PR DESCRIPTION
![Screenshot 2019-12-14 at 11 37 37](https://user-images.githubusercontent.com/2401925/70848240-474dcd00-1e66-11ea-9723-4a93e4b34a5a.png)

Stops the behaviour in the screenshot above by adding a z-index property to the context-menu class