### PR TITLE
Fix tree-view commands by setting focus

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,18 @@ function convertElectronMenu(
             sublabel: getTextForAccelerator(item.accelerator),
             onClick: () => {
               if (item.command != null) {
+                if (item.command.indexOf('tree-view:') === 0) {
+                  const pkg = atom.packages.getActivePackage('tree-view');
+
+                  if (pkg && pkg.mainModule && pkg.mainModule.getTreeViewInstance) {
+                    const treeView = pkg.mainModule.getTreeViewInstance();
+
+                    if (treeView.focus) {
+                      treeView.focus();
+                    }
+                  }
+                }
+
                 atom.commands.dispatch(event.target, item.command);
               }
             },


### PR DESCRIPTION
This fixes #2 by giving the _tree-view_ focus before dispatching any _tree-view_ commands. I am not quite sure whether this is the correct approach but it appears to work on my machine for both the _rename_ and _duplicate_ commands.

The issue appears to be that the _tree-view_ package checks whether the _tree-view_ is in focus when dispatching the commands. It looks like this custom menu resets the focus and causes the unintended behaviour of breaking the commands.